### PR TITLE
DESCW-3169 tested local linting, configured github workflows

### DIFF
--- a/.github/workflows/phpcs-validate.yml
+++ b/.github/workflows/phpcs-validate.yml
@@ -2,11 +2,15 @@ name: PHPCS Validation
 permissions:
   contents: read
 on:
-  pull_request:
   workflow_dispatch:
+  push:
+    paths:
+      - "!vendor/**"
+      - "!dist/**"
+  pull_request:
     paths:
       - "!vendor/**"
       - "!dist/**"
 jobs:
   phpcs-validation:
-    uses: bcgov/des-git-workflows/.github/workflows/phpcs-validate.yml@main
+    uses: bcgov/des-git-workflows/.github/workflows/phpcs-validate.yml@1.0.0

--- a/SETUP_CHECKLIST.md
+++ b/SETUP_CHECKLIST.md
@@ -3,11 +3,10 @@
 - [x] main branch is default
 - [x] branch protection rules (1 approver, no stale PR, require codeowners)
 - [x] CODEOWNERS setup
-- [x] README.md updated to reflect feature/functionality
-  - have used the readme from the bcgov-food-directory theme on bitbucket
-  - some references to gravity forms (to be replaced by CHEFS) were removed
-  - some formatting changes to the markdown
+- [ ] README.md updated to reflect feature/functionality
+  - use blank readme until functionality has been added to the plugin
 - [ ] linter and code validations workflows are setup (js/css/php)
+
 - [ ] tests workflows (js/php)
 - [ ] Sonarcloud / dependabot configured and enabled
 - [ ] Satis webhook

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "bcgov-wordpress-plugin-template",
+  "name": "bcfooddirectory-wordpress-plugin",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "bcgov-wordpress-plugin-template",
+      "name": "bcfooddirectory-wordpress-plugin",
       "version": "1.0.0",
       "license": "GPL-2.0-or-later",
       "devDependencies": {


### PR DESCRIPTION
This pull request updates the PHP CodeSniffer (PHPCS) workflow configuration and revises the setup checklist documentation. The workflow update ensures more precise triggering and version pinning, while the checklist clarifies requirements for the `README.md` and linter setup.

**Workflow configuration improvements:**

* The `.github/workflows/phpcs-validate.yml` workflow now triggers on both `push` and `pull_request` events, but excludes changes in the `vendor` and `dist` directories for both events. This prevents unnecessary runs when dependencies or build artifacts are updated.
* The workflow now uses a specific version (`1.0.0`) of the shared PHPCS validation workflow instead of tracking the `main` branch, ensuring stability and reproducibility.

**Documentation updates:**

* The `SETUP_CHECKLIST.md` checklist item for updating the `README.md` has been changed from completed to incomplete, with instructions to use a blank README until plugin functionality is added.
* Minor formatting changes clarify that linter and code validation workflows should be set up for JavaScript, CSS, and PHP.- will push and test these workflows: if they all pass, I create a PR and merge it.